### PR TITLE
Resolve bugs to test run MINIMAX search only starting from river stage.

### DIFF
--- a/honestminimaxplayer.py
+++ b/honestminimaxplayer.py
@@ -45,7 +45,7 @@ class HonestMiniMaxPlayer(BasePokerPlayer):
 
         state = State(round_state, hole_card_indices, community_card_indices)
 
-        if state.street == 'preflop':
+        if state.street == 'preflop' or state.street == 'flop' or state.street == 'turn':
 
             #TODO Check lookup table, fold if necessary, call if hold cards good to go
             action = 'call'
@@ -105,7 +105,7 @@ class HonestMiniMaxPlayer(BasePokerPlayer):
 
             def chance_node(state):
                 
-                if PokerGame.terminal_test(state): # terminal node reached
+                if PokerGame.terminal_test(state):
                     return PokerGame.utility(state)
 
                 print("____Going to the next street by flipping one more community card____")
@@ -143,9 +143,13 @@ class HonestMiniMaxPlayer(BasePokerPlayer):
                     v = min_value(new_state)
                 action_utilities[a] = v
 
-            for key, value in action_utilities:
-                if value > maximum:
-                    action = key
+            print("Expected minimax is calculated, Waiting for Argmax(action)...")
+
+            for key in action_utilities:
+                if action_utilities[key] > maximum:
+                    action = key.lower()
+
+            print("Argmax action is chosen to be: " + action)
 
         return action
 

--- a/utils/game_state.py
+++ b/utils/game_state.py
@@ -421,7 +421,7 @@ class PokerGame:
         
         for index in indices:
             rank_index = index % 13
-            suite_index = (index - rank) / 13
+            suite_index = (index - rank_index) / 13
             card.append(suite[suite_index] + rank[rank_index])
 
         return card
@@ -440,7 +440,7 @@ class PokerGame:
             # use monte-carlo hand strength estimator
             hole_card = gen_cards(PokerGame.convert_index_to_card(state.hole_card_indices))
             community_card = gen_cards(PokerGame.convert_index_to_card(state.community_card_indices))
-            win_probability = estimate_hole_card_win_rate(nb_simulation=1000, nb_player=2, hole_card=hole_card, community_card=community_card)
+            win_probability = estimate_hole_card_win_rate(nb_simulation=200, nb_player=2, hole_card=hole_card, community_card=community_card)
             expected_win = (2 * win_probability - 1) * state.get_main_pot()
 
             if state.current_player == state._round_state['next_player']:
@@ -460,4 +460,11 @@ class PokerGame:
         pp = pprint.PrettyPrinter(indent=2)
         pp.pprint(state.get_new_round_state())
         """Return True if this is a final state for the game."""
-        return state.is_terminal or (state.street == 'river' and (state.street in state.new_round_state['action_histories'] and state.new_round_state['action_histories'][state.street][-1] == 'CALL'))
+        if state.is_terminal:
+            return True
+        elif 'river' not in state.new_round_state['action_histories']:
+            return False
+        else:
+            river_actions = state.new_round_state['action_histories']['river']
+            print(river_actions)
+            return len(river_actions) > 1 and river_actions[-1]['action'] == 'CALL'


### PR DESCRIPTION
Latest: even with monte-carlo simulation of 200 rounds + only start minimax at river stage (i.e. chance node is not counted yet) + extended timeout to 0.2s, we still experience an Action TimedOut.